### PR TITLE
Implement API key authentication middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A high-performance, cost-effective email validation service designed for indie h
 This is a completely free and open source email validation API that never stores your data. Built to support solopreneurs and the developer community. Features include:
 - Zero data storage - your emails are never saved!
 - GDPR, CCPA, and PIPEDA compliant
-- No authentication required
+- API key authentication via the `apikey` header
 - No usage limits
 - Quick response times
 - Batch validation up to 100 emails

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+)
+
+// APIKeyMiddleware checks the 'apikey' header against the API_KEY environment variable.
+// If the key doesn't match, it returns 403 Forbidden with a Russian message.
+func APIKeyMiddleware(next http.Handler) http.Handler {
+	requiredKey := os.Getenv("API_KEY")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requiredKey != "" {
+			if r.Header.Get("apikey") != requiredKey {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("Доступ запрещен"))
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"emailvalidator/internal/api"
+	"emailvalidator/internal/middleware"
 	"emailvalidator/internal/service"
 	"emailvalidator/pkg/monitoring"
 )
@@ -46,8 +47,9 @@ func main() {
 	apiMux.HandleFunc("/typo-suggestions", handler.HandleTypoSuggestions)
 	apiMux.HandleFunc("/status", handler.HandleStatus)
 
-	// Wrap API routes with monitoring
-	monitoredHandler := monitoring.MetricsMiddleware(apiMux)
+	// Wrap API routes with authentication and monitoring
+	authHandler := middleware.APIKeyMiddleware(apiMux)
+	monitoredHandler := monitoring.MetricsMiddleware(authHandler)
 	finalMux.Handle("/api/", http.StripPrefix("/api", monitoredHandler))
 
 	// Register metrics endpoint


### PR DESCRIPTION
## Summary
- add middleware to enforce API key authentication via `apikey` header
- use the new middleware in `main.go`
- document API key requirement in README

## Testing
- `go test ./... -v -skip "Load"` *(fails: TestNullMXRecordAcceptance)*
- `CI=1 go test ./... -v -skip "Load"` *(fails: TestNullMXRecordAcceptance)*

------
https://chatgpt.com/codex/tasks/task_b_68557440de308333a258b478b18851bc